### PR TITLE
fix: Maintain preferences codestyle

### DIFF
--- a/extensions/gif-search/src/models/giphy.ts
+++ b/extensions/gif-search/src/models/giphy.ts
@@ -3,7 +3,7 @@ import { formatRelative } from "date-fns";
 import type { IGif as GiphyGif } from "@giphy/js-types";
 
 import { APIOpt, IGif, IGifAPI, slugify } from "../models/gif";
-import { getPreferenceValues } from "@raycast/api";
+import { getGiphyLocale } from "../preferences";
 
 const API_BASE_URL = "https://gif-search.raycast.com/api/giphy";
 
@@ -14,7 +14,7 @@ export default async function giphy(type?: "gifs" | "videos") {
       reqUrl.searchParams.set("q", term);
       reqUrl.searchParams.set("limit", opt?.limit?.toString() ?? "10");
       reqUrl.searchParams.set("offset", opt?.offset?.toString() ?? "0");
-      reqUrl.searchParams.set("lang", getPreferenceValues().giphyLocale);
+      reqUrl.searchParams.set("lang", getGiphyLocale());
 
       if (type) {
         reqUrl.searchParams.set("type", type);
@@ -32,7 +32,7 @@ export default async function giphy(type?: "gifs" | "videos") {
       const reqUrl = new URL(API_BASE_URL);
       reqUrl.searchParams.set("limit", opt?.limit?.toString() ?? "10");
       reqUrl.searchParams.set("offset", opt?.offset?.toString() ?? "0");
-      reqUrl.searchParams.set("lang", getPreferenceValues().giphyLocale);
+      reqUrl.searchParams.set("lang", getGiphyLocale());
 
       if (type) {
         reqUrl.searchParams.set("type", type);

--- a/extensions/gif-search/src/models/tenor.ts
+++ b/extensions/gif-search/src/models/tenor.ts
@@ -2,7 +2,7 @@ import { formatRelative, fromUnixTime } from "date-fns";
 import fetch from "node-fetch";
 
 import { APIOpt, IGif, IGifAPI, slugify } from "../models/gif";
-import { getPreferenceValues } from "@raycast/api";
+import { getTenorLocale } from "../preferences";
 
 export interface TenorResults {
   results: TenorGif[];
@@ -39,7 +39,7 @@ export default async function tenor() {
   return <IGifAPI>{
     async search(term: string, opt?: APIOpt) {
       const reqUrl = new URL(API_BASE_URL);
-      reqUrl.searchParams.set("locale", getPreferenceValues().tenorLocale);
+      reqUrl.searchParams.set("locale", getTenorLocale());
       reqUrl.searchParams.set("q", term);
       reqUrl.searchParams.set("media_filter", "gif,nanogif");
       reqUrl.searchParams.set("limit", opt?.limit?.toString() ?? "10");
@@ -59,7 +59,7 @@ export default async function tenor() {
 
     async trending(opt?: APIOpt) {
       const reqUrl = new URL(API_BASE_URL);
-      reqUrl.searchParams.set("locale", getPreferenceValues().tenorLocale);
+      reqUrl.searchParams.set("locale", getTenorLocale());
       reqUrl.searchParams.set("media_filter", "gif,nanogif");
       reqUrl.searchParams.set("limit", opt?.limit?.toString() ?? "10");
 

--- a/extensions/gif-search/src/preferences.ts
+++ b/extensions/gif-search/src/preferences.ts
@@ -59,3 +59,11 @@ export function getGridTrendingItemSize() {
 export function getHideFilename(): boolean {
   return preferences.hideFilename;
 }
+
+export function getGiphyLocale(): string {
+  return preferences.giphyLocale;
+}
+
+export function getTenorLocale(): string {
+  return preferences.tenorLocale;
+}


### PR DESCRIPTION
Make new preferences match the existing code style

## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used in the `README` are located outside the metadata folder if they were not generated with our [metadata tool](https://developers.raycast.com/basics/prepare-an-extension-for-store#how-to-use-it)
